### PR TITLE
Update HealthKit Data Collection.

### DIFF
--- a/PICS/PICSDelegate.swift
+++ b/PICS/PICSDelegate.swift
@@ -72,7 +72,24 @@ class PICSDelegate: SpeziAppDelegate {
             settings: settings
         )
     }
+
+    // Currently, we collect data for the past three months as the patients
+    // have in-hospital appointments every three months. In the future, we
+    // might change this to collecting data since three months before the first
+    // or the closest incoming appointment if we collect the appointment dates.
+    private var monthTraceBack = -3
     
+    private var predicateThreeMonth: NSPredicate {
+        let calendar = Calendar(identifier: .gregorian)
+        let today = calendar.startOfDay(for: Date())
+        guard let endDate = calendar.date(byAdding: .day, value: 1, to: today) else {
+            fatalError("*** Unable to calculate the end time ***")
+        }
+        guard let startDate = calendar.date(byAdding: .month, value: monthTraceBack, to: endDate) else {
+            fatalError("*** Unable to calculate the start time ***")
+        }
+        return HKQuery.predicateForSamples(withStart: startDate, end: endDate)
+    }
     
     private var healthKit: HealthKit {
         HealthKit {
@@ -80,15 +97,18 @@ class PICSDelegate: SpeziAppDelegate {
             // 10 minutes, and Step Count daily.
             CollectSample(
                 HKQuantityType(.stepCount),
-                deliverySetting: .anchorQuery(.afterAuthorizationAndApplicationWillLaunch)
+                predicate: predicateThreeMonth,
+                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch, saveAnchor: false)
             )
             CollectSample(
                 HKQuantityType(.heartRate),
-                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
+                predicate: predicateThreeMonth,
+                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch, saveAnchor: false)
             )
             CollectSample(
                 HKQuantityType(.oxygenSaturation),
-                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
+                predicate: predicateThreeMonth,
+                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch, saveAnchor: false)
             )
         }
     }


### PR DESCRIPTION
# Update HealthKit Data Collection.

## :recycle: Current situation & Problem
This PR is used to resolve the problem described in issue #10. From the tasks mentioned in the issue, this PR aims to collect the data in the desired format and collect all of the necessary data.


## :gear: Release Notes 
- Instead of dumping the raw JSON data, we currently upload data as JSON documents with three key-values pairs for `startDate`, `endDate`, and `value` (with the unit `count` for step count, `count/min` for heart rate, and `percent` for oxygen saturation). Examples are attached below. the field `startDate` and `endDate` actually represent the start and end time, but we collect them in the way as the same as HealthKit original data.
- Data are currently collected for the past three months from today as the patients have in-hospotal appointments every three months. In the future, we could change this the date to start collecting data to three months before closest incoming appointment dates if we record such data.
- Temporarily mark the data collect save-anchor option to false so that we are able to re-collect the data (in the new format) to verify that we are collecting data as expected. This would be reversed in the future and it would possibly not cause issues as data are stored with their UUIDa as names so that duplicated data will replace the old ones.

Examples of current collected data.
- Oxygen saturation
<img width="1040" alt="image" src="https://github.com/CS342/2024-PICS/assets/32094663/0ec5f1bb-4aad-4da0-8316-087be8fd2cab">
- Heart rate
<img width="1128" alt="image" src="https://github.com/CS342/2024-PICS/assets/32094663/396cabf6-b4a7-45de-97a3-97dd684c5f9c">
- Step count
<img width="1107" alt="image" src="https://github.com/CS342/2024-PICS/assets/32094663/c3826a69-562f-483b-9df8-e3ce8d7672c3">


## :books: Documentation
No extra documentation are added. Comments are added in codes for clarifications.


## :white_check_mark: Testing
Tested locally with simulator and manually added health activity data (step count, oxygen saturation, and heart rate).

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
