### PR TITLE
Using AppStorage for Appointment Info

### DIFF
--- a/PICS.xcodeproj/project.pbxproj
+++ b/PICS.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		74C593952B720781002D0274 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		74C593972B720B5E002D0274 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		74C5939A2B720F1B002D0274 /* (null) in Resources */ = {isa = PBXBuildFile; };
+		86400D192B7C4B6D009FEC10 /* ApptInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86400D182B7C4B6D009FEC10 /* ApptInfo.swift */; };
 		8644E6712B6C7243001218D0 /* AppointmentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8644E6702B6C7243001218D0 /* AppointmentView.swift */; };
 		8644E67B2B6C75B1001218D0 /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8644E67A2B6C75B1001218D0 /* MapView.swift */; };
 		8644E6842B72046B001218D0 /* GettingThere.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8644E6832B72046B001218D0 /* GettingThere.swift */; };
@@ -160,6 +161,7 @@
 		748117162B74BC3E00801A9A /* EQ5D5L.json.license */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = EQ5D5L.json.license; sourceTree = "<group>"; };
 		748117192B74BC5B00801A9A /* Self-MNA.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "Self-MNA.json"; sourceTree = "<group>"; };
 		7481171B2B74BC6D00801A9A /* PHQ-4.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "PHQ-4.json"; sourceTree = "<group>"; };
+		86400D182B7C4B6D009FEC10 /* ApptInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApptInfo.swift; sourceTree = "<group>"; };
 		8644E6702B6C7243001218D0 /* AppointmentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppointmentView.swift; sourceTree = "<group>"; };
 		8644E67A2B6C75B1001218D0 /* MapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapView.swift; sourceTree = "<group>"; };
 		8644E6832B72046B001218D0 /* GettingThere.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GettingThere.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 			children = (
 				2FE5DC3129EDD7CA004B9AB4 /* OnboardingFlow.swift */,
 				2FE5DC3429EDD7CA004B9AB4 /* Welcome.swift */,
+				86400D182B7C4B6D009FEC10 /* ApptInfo.swift */,
 				2FE5DC3229EDD7CA004B9AB4 /* InterestingModules.swift */,
 				2FE5DCAC29EE6107004B9AB4 /* AccountOnboarding.swift */,
 				2FE5DC2F29EDD7CA004B9AB4 /* Consent.swift */,
@@ -647,6 +650,7 @@
 			files = (
 				2FE5DC4129EDD7EE004B9AB4 /* StorageKeys.swift in Sources */,
 				2FE5DCB129EE6107004B9AB4 /* AccountOnboarding.swift in Sources */,
+				86400D192B7C4B6D009FEC10 /* ApptInfo.swift in Sources */,
 				2F4FC8D729EE69D300BFFE26 /* MockUpload.swift in Sources */,
 				2FE5DC3A29EDD7CA004B9AB4 /* Welcome.swift in Sources */,
 				2FE5DC3829EDD7CA004B9AB4 /* InterestingModules.swift in Sources */,

--- a/PICS/Appointment/AppointmentView.swift
+++ b/PICS/Appointment/AppointmentView.swift
@@ -9,11 +9,17 @@
 import SwiftUI
 
 struct AppointmentView: View {
+    @AppStorage("appt1") private var appt1Data: Data?
+    @AppStorage("appt2") private var appt2Data: Data?
+
+    @State private var appt1 = Date()
+    @State private var appt2 = Date()
+    
     var body: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .leading) {
-                AppointmentBlock(date: "June 24, 2024", time: "4:00 PM")
-                AppointmentBlock(date: "September 24, 2024", time: "4:00 PM")
+                AppointmentBlock(date: formattedDate(appt1), time: formattedTime(appt1))
+                AppointmentBlock(date: formattedDate(appt2), time: formattedTime(appt2))
             }
             .padding()
             
@@ -24,7 +30,31 @@ struct AppointmentView: View {
             Spacer()
         }
         .background(Color(UIColor.systemGray6))
+        .onAppear {
+                    initializeAppointments()
+        }
     }
+    private func initializeAppointments() {
+           let decoder = JSONDecoder()
+           if let appt1Data = appt1Data, let decodedAppt1 = try? decoder.decode(Date.self, from: appt1Data) {
+               appt1 = decodedAppt1
+           }
+           if let appt2Data = appt2Data, let decodedAppt2 = try? decoder.decode(Date.self, from: appt2Data) {
+               appt2 = decodedAppt2
+           }
+       }
+
+       private func formattedDate(_ date: Date) -> String {
+           let formatter = DateFormatter()
+           formatter.dateFormat = "MMMM dd, yyyy"
+           return formatter.string(from: date)
+       }
+
+       private func formattedTime(_ date: Date) -> String {
+           let formatter = DateFormatter()
+           formatter.dateFormat = "h:mm a"
+           return formatter.string(from: date)
+       }
 }
 
 #Preview {

--- a/PICS/Onboarding/ApptInfo.swift
+++ b/PICS/Onboarding/ApptInfo.swift
@@ -22,13 +22,16 @@ struct ApptInfo: View {
     @Environment(OnboardingNavigationPath.self) private var onboardingNavigationPath
     
     // Define keys for AppStorage
+    private let appt0Key = "appt0"
     private let appt1Key = "appt1"
     private let appt2Key = "appt2"
 
     // Use @AppStorage to store the selected dates
+    @AppStorage("appt0") private var appt0Data: Data?
     @AppStorage("appt1") private var appt1Data: Data?
     @AppStorage("appt2") private var appt2Data: Data?
 
+    @State private var appt0 = Date()
     @State private var appt1 = Date()
     @State private var appt2 = Date()
 
@@ -39,6 +42,10 @@ struct ApptInfo: View {
             },
             contentView: {
                 VStack {
+                    Text(String(localized: "APPTQ_0"))
+                                           .font(.headline)
+                    DateTimePickerView(selectedDateTime: $appt0)
+                        .padding(.bottom, 32)
                     Text(String(localized: "APPTQ_1"))
                                            .font(.headline)
                     DateTimePickerView(selectedDateTime: $appt1)

--- a/PICS/Onboarding/ApptInfo.swift
+++ b/PICS/Onboarding/ApptInfo.swift
@@ -56,7 +56,7 @@ struct ApptInfo: View {
                 }
             },
             actionView: {
-                OnboardingActionsView("WELCOME_BUTTON") {
+                OnboardingActionsView("INTERESTING_MODULES_BUTTON") {
                     appt1Data = try? JSONEncoder().encode(appt1)
                     appt2Data = try? JSONEncoder().encode(appt2)
                     

--- a/PICS/Onboarding/ApptInfo.swift
+++ b/PICS/Onboarding/ApptInfo.swift
@@ -1,0 +1,71 @@
+//
+// This source file is part of the PICS based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziOnboarding
+import SwiftUI
+
+struct DateTimePickerView: View {
+    @Binding var selectedDateTime: Date
+
+    var body: some View {
+        DatePicker("Date and Time:", selection: $selectedDateTime, displayedComponents: [.date, .hourAndMinute])
+    }
+}
+
+
+struct ApptInfo: View {
+    @Environment(OnboardingNavigationPath.self) private var onboardingNavigationPath
+    
+    // Define keys for AppStorage
+    private let appt1Key = "appt1"
+    private let appt2Key = "appt2"
+
+    // Use @AppStorage to store the selected dates
+    @AppStorage("appt1") private var appt1Data: Data?
+    @AppStorage("appt2") private var appt2Data: Data?
+
+    @State private var appt1 = Date()
+    @State private var appt2 = Date()
+
+    var body: some View {
+        OnboardingView(
+            titleView: {
+                OnboardingTitleView(title: "APPTQ_TITLE", subtitle: "APPTQ_SUBTITLE")
+            },
+            contentView: {
+                VStack {
+                    Text(String(localized: "APPTQ_1"))
+                                           .font(.headline)
+                    DateTimePickerView(selectedDateTime: $appt1)
+                        .padding(.bottom, 32)
+                    Text(String(localized: "APPTQ_2"))
+                                           .font(.headline)
+                    DateTimePickerView(selectedDateTime: $appt2)
+                }
+            },
+            actionView: {
+                OnboardingActionsView("WELCOME_BUTTON") {
+                    appt1Data = try? JSONEncoder().encode(appt1)
+                    appt2Data = try? JSONEncoder().encode(appt2)
+                    
+                    onboardingNavigationPath.nextStep()
+                }
+            }
+        )
+        .padding(.top, 24)
+    }
+}
+
+
+#if DEBUG
+#Preview {
+    OnboardingStack {
+        ApptInfo()
+    }
+}
+#endif

--- a/PICS/Onboarding/OnboardingFlow.swift
+++ b/PICS/Onboarding/OnboardingFlow.swift
@@ -46,6 +46,7 @@ struct OnboardingFlow: View {
             if HKHealthStore.isHealthDataAvailable() && !healthKitAuthorization {
                 HealthKitPermissions()
             }
+            ApptInfo()
         }
             .interactiveDismissDisabled(!completedOnboardingFlow)
     }
@@ -62,7 +63,6 @@ struct OnboardingFlow: View {
             AccountConfiguration {
                 MockUserIdPasswordAccountService()
             }
-
             PICSScheduler()
         }
 }

--- a/PICS/Onboarding/Welcome.swift
+++ b/PICS/Onboarding/Welcome.swift
@@ -16,7 +16,7 @@ struct Welcome: View {
     
     var body: some View {
         OnboardingView(
-            title: "WELCOME_TITLE",
+            title: "APPTQ_TITLE",
             subtitle: "WELCOME_SUBTITLE",
             areas: [
                 OnboardingInformationView.Content(

--- a/PICS/Onboarding/Welcome.swift
+++ b/PICS/Onboarding/Welcome.swift
@@ -16,7 +16,7 @@ struct Welcome: View {
     
     var body: some View {
         OnboardingView(
-            title: "APPTQ_TITLE",
+            title: "WELCOME_TITLE",
             subtitle: "WELCOME_SUBTITLE",
             areas: [
                 OnboardingInformationView.Content(

--- a/PICS/Resources/Localizable.xcstrings
+++ b/PICS/Resources/Localizable.xcstrings
@@ -94,6 +94,50 @@
         }
       }
     },
+    "APPTQ_1" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First Follow-Up Appointment:"
+          }
+        }
+      }
+    },
+    "APPTQ_2" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Second Follow-Up Appointment:"
+          }
+        }
+      }
+    },
+    "APPTQ_SUBTITLE" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please enter information on your follow-up appointments:"
+          }
+        }
+      }
+    },
+    "APPTQ_TITLE" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appointment Information"
+          }
+        }
+      }
+    },
     "CLOSE" : {
       "comment" : "MARK: General",
       "localizations" : {

--- a/PICS/Resources/Localizable.xcstrings
+++ b/PICS/Resources/Localizable.xcstrings
@@ -94,6 +94,17 @@
         }
       }
     },
+    "APPTQ_0" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Discharge Date:"
+          }
+        }
+      }
+    },
     "APPTQ_1" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -122,7 +133,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Please enter information on your follow-up appointments:"
+            "value" : "Please enter information on your discharge date and follow-up appointments:"
           }
         }
       }


### PR DESCRIPTION
# *Using AppStorage for Appointment Info*

## :recycle: Current situation & Problem
I was previously using placeholder data for the appointment information. We needed a way to get and save the information about when the appointments are. 

## :gear: Release Notes 
- Created a new screen in the onboarding view to get appointment information
- Stored the date and time info using @AppStorage
- Replaced the values in the appointment information page to use the new saved values

@AppStorage("appt0") private var appt0Data: Data? --> stores the information for the discharge date
@AppStorage("appt1") private var appt1Data: Data? --> stores the date/time for the first appointment
@AppStorage("appt2") private var appt2Data: Data? --> stores the date/time for the second appointment

For specific details on how to decode the data type and convert it to Date/Time format, please view the AppointmentView screen inside of the Appointment folder.

**EDIT:** This has since changed. Please view [this PR](https://github.com/CS342/2024-PICS/pull/41) to see how I've made this a global variable and stored these functions - it no longer requires decoding in the files themselves. 

## :books: Documentation
There is no relevant Spezi documentation here!


## :white_check_mark: Testing
All tests pass


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
