### PR TITLE
Refine Health Dashboard Visualization

### DIFF
--- a/PICS/HealthVisulization/HKVisualization.swift
+++ b/PICS/HealthVisulization/HKVisualization.swift
@@ -152,7 +152,7 @@ struct HKVisualization: View {
          let healthStore = HKHealthStore()
          // Run a HKSampleQuery to fetch the health kit data.
          guard let quantityType = HKObjectType.quantityType(forIdentifier: quantityTypeIDF) else {
-             fatalError("*** Unable to create a step count type ***")
+             fatalError("*** Unable to create a quantity type ***")
          }
          let sortDescriptors = [
              NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
@@ -203,7 +203,7 @@ struct HKVisualization: View {
         let healthStore = HKHealthStore()
         // Read the step counts per day for the past three months.
         guard let quantityType = HKObjectType.quantityType(forIdentifier: quantityTypeIDF) else {
-            fatalError("*** Unable to create a step count type ***")
+            fatalError("*** Unable to create a quantity type ***")
         }
         let query = if quantityTypeIDF == HKQuantityTypeIdentifier.stepCount {
             HKStatisticsCollectionQuery(
@@ -282,7 +282,7 @@ struct HKVisualization: View {
         case .stepCount:
             return quantity.doubleValue(for: .count())
         case .oxygenSaturation:
-            return quantity.doubleValue(for: HKUnit.percent()) * 100
+            return quantity.doubleValue(for: .percent()) * 100
         case .heartRate:
             return quantity.doubleValue(for: HKUnit(from: "count/min"))
         default:

--- a/PICS/HealthVisulization/HKVisualization.swift
+++ b/PICS/HealthVisulization/HKVisualization.swift
@@ -93,7 +93,11 @@ struct HKVisualization: View {
     
     func readAllHKData(ensureUpdate: Bool = false) {
         // Generate the dates and predicates for all HealthKit queries.
-        let endDate = Date()
+        let startOfToday: Date = Calendar.current.startOfDay(for: Date())
+        guard let endDate = Calendar.current.date(byAdding: DateComponents(hour: 23, minute: 59, second: 59), to: startOfToday) else {
+            fatalError("*** Unable to create an end date ***")
+        }
+        // Collect data for the previous two weeks.
         guard let startDate = Calendar.current.date(byAdding: .day, value: -14, to: endDate) else {
             fatalError("*** Unable to create a start date ***")
         }
@@ -239,10 +243,7 @@ struct HKVisualization: View {
         var allData: [HKData] = []
         // Enumerate over all the statistics objects between the start and end dates.
         results.enumerateStatistics(from: startDate, to: endDate) { statistics, _ in
-            // The actual statistics collected is for date + 1.
-            guard let date = Calendar.current.date(byAdding: .day, value: 1, to:   statistics.startDate) else {
-                fatalError("*** Unable to add a day to a date ***")
-            }
+            let date = statistics.endDate
             var curSum = 0.0
             var curMax = 0.0
             var curAvg = 0.0

--- a/PICS/HealthVisulization/HKVisualization.swift
+++ b/PICS/HealthVisulization/HKVisualization.swift
@@ -14,14 +14,19 @@ import SwiftUI
 
 struct HKData: Identifiable {
     var date: Date
-    var value: Double
     var id = UUID()
+    var sumValue: Double
+    var avgValue: Double
+    var minValue: Double
+    var maxValue: Double
 }
 
 struct HKVisualization: View {
     @State var stepData: [HKData] = []
     @State var heartRateData: [HKData] = []
     @State var oxygenSaturationData: [HKData] = []
+    @State var heartRateScatterData: [HKData] = []
+    @State var oxygenSaturationScatterData: [HKData] = []
 
     var visualizationList: some View {
         self.readAllHKData()
@@ -31,7 +36,10 @@ struct HKVisualization: View {
                     data: self.stepData,
                     xName: "Time",
                     yName: "Step Count",
-                    title: String(localized: "HKVIZ_PLOT_STEP_TITLE")
+                    title: String(localized: "HKVIZ_PLOT_STEP_TITLE"),
+                    chartType: "bars",
+                    threshold: 5000.0,
+                    helperText: String(localized: "HKVIZ_PLOT_STEP_RECOMD")
                 )
             }
             Section {
@@ -39,7 +47,9 @@ struct HKVisualization: View {
                     data: self.heartRateData,
                     xName: "Time",
                     yName: "Heart Rate Per Minute",
-                    title: String(localized: "HKVIZ_PLOT_HEART_TITLE")
+                    title: String(localized: "HKVIZ_PLOT_HEART_TITLE"),
+                    chartType: "maxMin",
+                    scatterData: self.heartRateScatterData
                 )
             }
             Section {
@@ -47,7 +57,11 @@ struct HKVisualization: View {
                     data: self.oxygenSaturationData,
                     xName: "Time",
                     yName: "Oxygen Saturation (precent)",
-                    title: String(localized: "HKVIZ_PLOT_OXYGEN_TITLE")
+                    title: String(localized: "HKVIZ_PLOT_OXYGEN_TITLE"),
+                    chartType: "maxMin",
+                    threshold: 94.0,
+                    helperText: String(localized: "HKVIZ_PLOT_OXYGEN_RECOMD"),
+                    scatterData: self.oxygenSaturationScatterData
                 )
             }
         }
@@ -87,10 +101,21 @@ struct HKVisualization: View {
         
         // Read step counts perday seperately with statistics query.
         if self.stepData.isEmpty || ensureUpdate {
-            self.readStepCountStats(startDate: startDate, endDate: endDate, predicate: predicate)
+            self.readHKStats(
+                startDate: startDate,
+                endDate: endDate,
+                predicate: predicate,
+                quantityTypeIDF: HKQuantityTypeIdentifier.stepCount
+            )
         }
         // Read the heart rate and oxygen saturation data.
         if self.heartRateData.isEmpty || ensureUpdate {
+            self.readHKStats(
+                startDate: startDate,
+                endDate: endDate,
+                predicate: predicate,
+                quantityTypeIDF: HKQuantityTypeIdentifier.heartRate
+            )
             self.readFromSampleQuery(
                 startDate: startDate,
                 endDate: endDate,
@@ -99,6 +124,12 @@ struct HKVisualization: View {
             )
         }
         if self.oxygenSaturationData.isEmpty || ensureUpdate {
+            self.readHKStats(
+                startDate: startDate,
+                endDate: endDate,
+                predicate: predicate,
+                quantityTypeIDF: HKQuantityTypeIdentifier.oxygenSaturation
+            )
             self.readFromSampleQuery(
                 startDate: startDate,
                 endDate: endDate,
@@ -109,92 +140,154 @@ struct HKVisualization: View {
     }
     
     func readFromSampleQuery(
+         startDate: Date,
+         endDate: Date,
+         predicate: NSPredicate,
+         quantityTypeIDF: HKQuantityTypeIdentifier
+     ) {
+         let healthStore = HKHealthStore()
+         // Run a HKSampleQuery to fetch the health kit data.
+         guard let quantityType = HKObjectType.quantityType(forIdentifier: quantityTypeIDF) else {
+             fatalError("*** Unable to create a step count type ***")
+         }
+         let sortDescriptors = [
+             NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+         ]
+         let query = HKSampleQuery(
+             sampleType: quantityType,
+             predicate: predicate,
+             limit: 2000,
+             sortDescriptors: sortDescriptors
+         ) { _, results, error in
+             guard error == nil else {
+                 print(print("Error retrieving health kit data: \(String(describing: error))"))
+                 return
+             }
+             if let results = results {
+                 // Retrieve quantity value and time for each data point.
+                 var collectedData: [HKData] = []
+                 for result in results {
+                     guard let result: HKQuantitySample = result as? HKQuantitySample else {
+                         print("Unexpected heart rate sample type received.")
+                         continue
+                     }
+                     var value = -1.0 // To be replaced below.
+                     if quantityTypeIDF == HKQuantityTypeIdentifier.oxygenSaturation {
+                         value = result.quantity.doubleValue(for: HKUnit.percent()) * 100
+                     } else if quantityTypeIDF == HKQuantityTypeIdentifier.heartRate {
+                         value = result.quantity.doubleValue(for: HKUnit(from: "count/min"))
+                     }
+                     let date = result.startDate
+                     collectedData.append(HKData(date: date, sumValue: value, avgValue: -1.0, minValue: -1.0, maxValue: -1.0))
+                 }
+                 if quantityTypeIDF == HKQuantityTypeIdentifier.oxygenSaturation {
+                     self.oxygenSaturationScatterData = collectedData
+                 } else if quantityTypeIDF == HKQuantityTypeIdentifier.heartRate {
+                     self.heartRateScatterData = collectedData
+                 }
+             }
+         }
+         healthStore.execute(query)
+     }
+    
+    func readHKStats(
         startDate: Date,
         endDate: Date,
         predicate: NSPredicate,
         quantityTypeIDF: HKQuantityTypeIdentifier
     ) {
         let healthStore = HKHealthStore()
-        // Run a HKSampleQuery to fetch the health kit data.
+        // Read the step counts per day for the past three months.
         guard let quantityType = HKObjectType.quantityType(forIdentifier: quantityTypeIDF) else {
             fatalError("*** Unable to create a step count type ***")
         }
-        let sortDescriptors = [
-            NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
-        ]
-        let query = HKSampleQuery(
-            sampleType: quantityType,
-            predicate: predicate,
-            limit: 2000,
-            sortDescriptors: sortDescriptors
-        ) { _, results, error in
-            guard error == nil else {
-                print(print("Error retrieving health kit data: \(String(describing: error))"))
-                return
-            }
-            if let results = results {
-                // Retrieve quantity value and time for each data point.
-                var collectedData: [HKData] = []
-                for result in results {
-                    guard let result: HKQuantitySample = result as? HKQuantitySample else {
-                        print("Unexpected heart rate sample type received.")
-                        continue
-                    }
-                    var value = -1.0 // To be replaced below.
-                    if quantityTypeIDF == HKQuantityTypeIdentifier.oxygenSaturation {
-                        value = result.quantity.doubleValue(for: HKUnit.percent()) * 100
-                    } else if quantityTypeIDF == HKQuantityTypeIdentifier.heartRate {
-                        value = result.quantity.doubleValue(for: HKUnit(from: "count/min"))
-                    }
-                    let date = result.startDate
-                    collectedData.append(HKData(date: date, value: value))
-                }
-                if quantityTypeIDF == HKQuantityTypeIdentifier.oxygenSaturation {
-                    self.oxygenSaturationData = collectedData
-                } else if quantityTypeIDF == HKQuantityTypeIdentifier.heartRate {
-                    self.heartRateData = collectedData
-                }
-            }
+        let query = if quantityTypeIDF == HKQuantityTypeIdentifier.stepCount {
+            HKStatisticsCollectionQuery(
+                quantityType: quantityType,
+                quantitySamplePredicate: predicate,
+                options: .cumulativeSum,
+                anchorDate: startDate,
+                intervalComponents: DateComponents(day: 1)
+            )
+        } else {
+            HKStatisticsCollectionQuery(
+                quantityType: quantityType,
+                quantitySamplePredicate: predicate,
+                options: [.discreteMax, .discreteMin, .discreteAverage],
+                anchorDate: startDate,
+                intervalComponents: DateComponents(day: 1)
+            )
         }
-        healthStore.execute(query)
-    }
-    
-    func readStepCountStats(startDate: Date, endDate: Date, predicate: NSPredicate) {
-        let healthStore = HKHealthStore()
-        // Read the step counts per day for the past three months.
-        guard let quantityType = HKObjectType.quantityType(forIdentifier: .stepCount) else {
-            fatalError("*** Unable to create a step count type ***")
-        }
-        let query = HKStatisticsCollectionQuery(
-            quantityType: quantityType,
-            quantitySamplePredicate: predicate,
-            options: .cumulativeSum,
-            anchorDate: startDate,
-            intervalComponents: DateComponents(day: 1)
-        )
         query.initialResultsHandler = { _, results, error in
             guard error == nil else {
                 print(print("Error retrieving health kit data: \(String(describing: error))"))
                 return
             }
             if let results = results {
-                updateStepCountResult(results: results, startDate: startDate, endDate: endDate)
+                updateQueryResult(results: results, startDate: startDate, endDate: endDate, quantityTypeIDF: quantityTypeIDF)
             }
         }
         healthStore.execute(query)
     }
     
-    func updateStepCountResult(results: HKStatisticsCollection, startDate: Date, endDate: Date) {
-        var stepData: [HKData] = []
+    func updateQueryResult(
+        results: HKStatisticsCollection,
+        startDate: Date,
+        endDate: Date,
+        quantityTypeIDF: HKQuantityTypeIdentifier
+    ) {
+        var allData: [HKData] = []
         // Enumerate over all the statistics objects between the start and end dates.
         results.enumerateStatistics(from: startDate, to: endDate) { statistics, _ in
+            // The actual statistics collected is for date + 1.
+            guard let date = Calendar.current.date(byAdding: .day, value: 1, to:   statistics.startDate) else {
+                fatalError("*** Unable to add a day to a date ***")
+            }
+            var curSum = 0.0
+            var curMax = 0.0
+            var curAvg = 0.0
+            var curMin = 0.0
             if let quantity = statistics.sumQuantity() {
-                let date = statistics.startDate
-                let value = quantity.doubleValue(for: .count())
-                stepData.append(HKData(date: date, value: value))
+                curSum = parseValue(quantity: quantity, quantityTypeIDF: quantityTypeIDF)
+            }
+            if let quantity = statistics.maximumQuantity() {
+                curMax = parseValue(quantity: quantity, quantityTypeIDF: quantityTypeIDF)
+            }
+            if let quantity = statistics.averageQuantity() {
+                curAvg = parseValue(quantity: quantity, quantityTypeIDF: quantityTypeIDF)
+            }
+            if let quantity = statistics.minimumQuantity() {
+                curMin = parseValue(quantity: quantity, quantityTypeIDF: quantityTypeIDF)
+            }
+            if curSum != 0.0 || curMin != 0.0 || curMin != 0.0 || curMax != 0.0 {
+                allData.append(HKData(date: date, sumValue: curSum, avgValue: curAvg, minValue: curMin, maxValue: curMax))
             }
         }
-        self.stepData = stepData
+        
+        switch quantityTypeIDF {
+        case .stepCount:
+            self.stepData = allData
+        case .oxygenSaturation:
+            self.oxygenSaturationData = allData
+        case .heartRate:
+            self.heartRateData = allData
+        default:
+            print("Unexpected quantity received:", quantityTypeIDF)
+        }
+    }
+    
+    func parseValue(quantity: HKQuantity, quantityTypeIDF: HKQuantityTypeIdentifier) -> Double {
+        switch quantityTypeIDF {
+        case .stepCount:
+            return quantity.doubleValue(for: .count())
+        case .oxygenSaturation:
+            return quantity.doubleValue(for: HKUnit.percent()) * 100
+        case .heartRate:
+            return quantity.doubleValue(for: HKUnit(from: "count/min"))
+        default:
+            print("Unexpected quantity received:", quantityTypeIDF)
+            return -1.0
+        }
     }
 }
 

--- a/PICS/HealthVisulization/HKVisualizationItem.swift
+++ b/PICS/HealthVisulization/HKVisualizationItem.swift
@@ -36,36 +36,21 @@ struct HKVisualizationItem: View {
                 .font(.caption)
                 .listRowSeparator(.hidden)
         }
-        // swiftlint:disable closure_body_length
         Chart {
-            if !self.scatterData.isEmpty {
-                ForEach(scatterData) { dataPoint in
-                    PointMark(
-                        x: .value(self.xName, dataPoint.date, unit: .day),
-                        y: .value(self.yName, dataPoint.sumValue)
-                    )
-                    .foregroundStyle(.opacity(0.2))
-                }
+            ForEach(scatterData) { dataPoint in
+                PointMark(
+                    x: .value(self.xName, dataPoint.date, unit: .day),
+                    y: .value(self.yName, dataPoint.sumValue)
+                )
+                .foregroundStyle(((self.threshold > 0 && dataPoint.sumValue > self.threshold) ? Color.blue : Color.accentColor).opacity(0.2))
             }
             ForEach(data) { dataPoint in
-                switch self.chartType {
-//                case "maxMin":
-//                    BarMark(
-//                        x: .value(self.xName, dataPoint.date, unit: .day),
-//                        yStart: .value(self.yName, dataPoint.minValue),
-//                        yEnd: .value(self.yName, dataPoint.maxValue),
-//                        width: .fixed(10)
-//                    )
-//                    .clipShape(Capsule())
-//                    .foregroundStyle((self.threshold > 0 && dataPoint.minValue > self.threshold) ? Color.blue : Color.accentColor)
-                default:
-                    BarMark(
-                        x: .value(self.xName, dataPoint.date, unit: .day),
-                        y: .value(self.yName, dataPoint.sumValue),
-                        width: .fixed(10)
-                    )
-                    .foregroundStyle(dataPoint.sumValue > self.threshold ? Color.blue : Color.accentColor)
-                }
+                BarMark(
+                    x: .value(self.xName, dataPoint.date, unit: .day),
+                    y: .value(self.yName, dataPoint.sumValue),
+                    width: .fixed(10)
+                )
+                .foregroundStyle(dataPoint.sumValue > self.threshold ? Color.blue : Color.accentColor)
                 if self.plotAvg {
                     LineMark(
                         x: .value(self.xName, dataPoint.date, unit: .day),

--- a/PICS/HealthVisulization/HKVisualizationItem.swift
+++ b/PICS/HealthVisulization/HKVisualizationItem.swift
@@ -18,26 +18,103 @@ struct HKVisualizationItem: View {
     var xName: String
     var yName: String
     var title: String
+    var chartType: String
+    var ymin: Double
+    var ymax: Double
+    var threshold: Double = -1.0
+    var helperText = ""
+    var plotAvg = false
+    var scatterData: [HKData] = []
     
     var body: some View {
         Text(self.title)
             .font(.title3.bold())
+            // Remove line below text.
+            .listRowSeparator(.hidden)
+        if !self.helperText.isEmpty {
+            Text(self.helperText)
+                .font(.caption)
+                .listRowSeparator(.hidden)
+        }
+        // swiftlint:disable closure_body_length
         Chart {
+            if !self.scatterData.isEmpty {
+                ForEach(scatterData) { dataPoint in
+                    PointMark(
+                        x: .value(self.xName, dataPoint.date, unit: .day),
+                        y: .value(self.yName, dataPoint.sumValue)
+                    )
+                    .foregroundStyle(.opacity(0.2))
+                }
+            }
             ForEach(data) { dataPoint in
-                PointMark(
-                    x: .value(self.xName, dataPoint.date.formatted(date: .numeric, time: .shortened)),
-                    y: .value(self.yName, dataPoint.value)
+                switch self.chartType {
+//                case "maxMin":
+//                    BarMark(
+//                        x: .value(self.xName, dataPoint.date, unit: .day),
+//                        yStart: .value(self.yName, dataPoint.minValue),
+//                        yEnd: .value(self.yName, dataPoint.maxValue),
+//                        width: .fixed(10)
+//                    )
+//                    .clipShape(Capsule())
+//                    .foregroundStyle((self.threshold > 0 && dataPoint.minValue > self.threshold) ? Color.blue : Color.accentColor)
+                default:
+                    BarMark(
+                        x: .value(self.xName, dataPoint.date, unit: .day),
+                        y: .value(self.yName, dataPoint.sumValue),
+                        width: .fixed(10)
+                    )
+                    .foregroundStyle(dataPoint.sumValue > self.threshold ? Color.blue : Color.accentColor)
+                }
+                if self.plotAvg {
+                    LineMark(
+                        x: .value(self.xName, dataPoint.date, unit: .day),
+                        y: .value(self.yName, dataPoint.avgValue)
+                    )
+                    .foregroundStyle(.purple)
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+                }
+            }
+            if self.threshold > 0 {
+                RuleMark(
+                    y: .value("Threshold", self.threshold)
                 )
+                .foregroundStyle(.black)
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [5]))
             }
         }
-        .padding(.top, 15)
+        .padding(.top, 10)
+        .chartYScale(domain: self.ymin...self.ymax)
+        .chartXAxis {
+            AxisMarks(values: .stride(by: .day, count: 3))
+        }
     }
     
-    init(data: [HKData], xName: String, yName: String, title: String) {
+    init(
+        data: [HKData],
+        xName: String,
+        yName: String,
+        title: String,
+        chartType: String,
+        threshold: Double = -1.0,
+        helperText: String = "",
+        scatterData: [HKData] = []
+    ) {
         self.data = data
         self.xName = xName
         self.yName = yName
         self.title = title
+        self.chartType = chartType
+        self.threshold = threshold
+        self.helperText = helperText
+        // Find max and min for y range.
+        self.ymax = data.map(\.maxValue).max() ?? 0
+        // For step data, we only have sum values.
+        self.ymax = max(self.ymax, data.map(\.sumValue).max() ?? 0)
+        self.ymin = data.map(\.minValue).min() ?? 0
+        // Plot average data if we have such data.
+        self.plotAvg = data.map(\.avgValue).max() ?? 0 > 0
+        self.scatterData = scatterData
     }
 }
 
@@ -46,6 +123,7 @@ struct HKVisualizationItem: View {
         data: [],
         xName: "Preview x axis",
         yName: "Preview y axis",
-        title: "Preview Title"
+        title: "Preview Title",
+        chartType: "PointMark"
     )
 }

--- a/PICS/PICSDelegate.swift
+++ b/PICS/PICSDelegate.swift
@@ -98,17 +98,17 @@ class PICSDelegate: SpeziAppDelegate {
             CollectSample(
                 HKQuantityType(.stepCount),
                 predicate: predicateThreeMonth,
-                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch, saveAnchor: false)
+                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
             )
             CollectSample(
                 HKQuantityType(.heartRate),
                 predicate: predicateThreeMonth,
-                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch, saveAnchor: false)
+                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
             )
             CollectSample(
                 HKQuantityType(.oxygenSaturation),
                 predicate: predicateThreeMonth,
-                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch, saveAnchor: false)
+                deliverySetting: .background(.afterAuthorizationAndApplicationWillLaunch)
             )
         }
     }

--- a/PICS/Resources/Localizable.xcstrings
+++ b/PICS/Resources/Localizable.xcstrings
@@ -296,6 +296,17 @@
         }
       }
     },
+    "HKVIZ_PLOT_OXYGEN_RECOMD" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Having your oxygen saturation over 94% is a good health indicator."
+          }
+        }
+      }
+    },
     "HKVIZ_PLOT_OXYGEN_TITLE" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -303,6 +314,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oxygen Saturation (%)"
+          }
+        }
+      }
+    },
+    "HKVIZ_PLOT_STEP_RECOMD" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We recommend to walk more than 5000 steps each day."
           }
         }
       }
@@ -698,6 +720,9 @@
       }
     },
     "This task has been completed!" : {
+
+    },
+    "Threshold" : {
 
     },
     "Weight" : {

--- a/PICSUITests/HealthVisualizationTests.swift
+++ b/PICSUITests/HealthVisualizationTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import XCTHealthKit
 
 class HealthVisualizationTests: XCTestCase {
     override func setUpWithError() throws {
@@ -22,6 +23,9 @@ class HealthVisualizationTests: XCTestCase {
     
     
     func testLoadHealthDashboard() throws {
+        // Add healthkit data to ensure the queries and plots are tested
+        try exitAppAndOpenHealth(.steps)
+
         // Check whether the components shows as expected.
         let app = XCUIApplication()
         // Go to the Health dashboard.


### PR DESCRIPTION
# Refine Health Dashboard Visualization

## :recycle: Current situation & Problem
As mentioned in issues #11 and #13, we want to visualize the important health sign data and help users interpret the trends (e.g. changes in averages, and daily max and min). This PR refines the current health dashboard by producing cleaner plots with data grouped by each day and adding trend lines for daily averages.

In future PR(s), we will enable the interaction with the chart. For example, we will show the daily max, min, and average when the user clicks on the points/bars in the plot.

## :gear: Release Notes 
- As in the plot below, group the data by each day, use a single bar plot for the sum step count per day, and use scatter plots with capacity for the heart rate and oxygen saturation.
- Add trend lines for the daily average for heart rate and oxygen saturation.
- Add threshold horizontal lines for step counts and oxygen saturation and change the color of points/bars above the threshold to blue.
- Revert the HK data collection saveAnchor option to default as we tested that the data are collected as expected to the firebase.

Note: in the below plot, we found that some data are missing for heart rate and oxygen saturation between Feb 10 to 13. This is expected as the data were not collected for those days.
<p float="left">
  <img src="https://github.com/CS342/2024-PICS/assets/32094663/399bd4dd-84a9-4d05-8a5a-0d0a91c973de" width="360" />
  <img src="https://github.com/CS342/2024-PICS/assets/32094663/ab0e5906-1914-4936-8178-48e350b94d90" width="360" /> 
</p>

## :books: Documentation
Related comments are entered in the codebase.

## :white_check_mark: Testing
Testing with the simulator and my real health data imported from my phone.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
