### PR TITLE
Refine Assessment Charts and Fix Bugs

### DIFF
--- a/PICS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PICS.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "a732a4b47f59e4f725a2ea10f0c77e93a7131117",
-        "version" : "9.3.0"
+        "revision" : "a637d318ae7ae246b02d7305121275bc75ed5565",
+        "version" : "9.4.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
-        "version" : "7.12.1"
+        "revision" : "830ffa9276e10267881f2697283c2fcd867603fd",
+        "version" : "7.13.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
-        "revision" : "9d108e9112aa1d65ce508facf804674546116d9c",
-        "version" : "1.22.3"
+        "revision" : "43aaef65e0c665daadf848761d560e446d350d3d",
+        "version" : "1.22.4"
       }
     },
     {
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/ResearchKitOnFHIR",
       "state" : {
-        "revision" : "300fbc0038df28f53a9b653298931f71aa6f0bb5",
-        "version" : "1.1.1"
+        "revision" : "7c2efdcb17796fc9ee686900304dbbe9dd4aaf85",
+        "version" : "1.1.2"
       }
     },
     {
@@ -183,10 +183,10 @@
     {
       "identity" : "spezifoundation",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziFoundation.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziFoundation",
       "state" : {
-        "revision" : "0346857e2f1d6fd4b1d950d271be6c82df97107f",
-        "version" : "1.0.2"
+        "revision" : "01af5b91a54f30ddd121258e81aff2ddc2a99ff9",
+        "version" : "1.0.4"
       }
     },
     {
@@ -212,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziOnboarding",
       "state" : {
-        "revision" : "91463ae190611bd14ef52b0657e8db3bf53c9ae8",
-        "version" : "1.1.0"
+        "revision" : "4971a82e94996ce0c3d8ecf64fdeec874a1f20d6",
+        "version" : "1.1.1"
       }
     },
     {
@@ -239,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziStorage.git",
       "state" : {
-        "revision" : "eaed2220375c35400aa69d1f96a8d32b7e66b1c7",
-        "version" : "1.0.0"
+        "revision" : "7d1c8ff8310e2f628f918fb535d80f368730ad6b",
+        "version" : "1.0.1"
       }
     },
     {
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziViews.git",
       "state" : {
-        "revision" : "d49f716e4a4d634604bb0dcd6d53df679b6c1358",
-        "version" : "1.3.0"
+        "revision" : "4d2a724d97c8f19ac7de7aa2c046b1cb3ef7b279",
+        "version" : "1.3.1"
       }
     },
     {

--- a/PICS/Assessment/Assessments.swift
+++ b/PICS/Assessment/Assessments.swift
@@ -26,11 +26,6 @@ struct Assessments: View {
         case stroopTest
     }
 
-    // Environment objects for app-wide settings and scheduling.
-    @Environment(PICSStandard.self) private var standard
-    @Environment(PICSScheduler.self) private var scheduler
-    @Environment(AppointmentInformation.self) private var appointmentInfo
-    
     // Binding to control the display of account-related UI.
     @Binding private var presentingAccount: Bool
     
@@ -44,74 +39,78 @@ struct Assessments: View {
     
     // Main body of the Assessments view, switching between the list of assessments and the currently active assessment.
     var assessmentList: some View {
-            List {
-                trailMakingTestSection
-                stroopTestSection
-            }
+        List {
+            trailMakingTestSection
+                .padding(10)
+            stroopTestSection
+                .padding(10)
         }
-        
-        var body: some View {
-            NavigationStack {
-                if assessmentsIP {
-                    // Displays the active assessment based on the currentTest state.
-                    switch currentTest {
-                    case .trailMaking:
-                        TrailMakingTaskView()
-                    case .stroopTest:
-                        StroopTestView()
-                    }
-                } else {
-                    assessmentList
-                        .navigationTitle(String(localized: "ASSESSMENTS_NAVIGATION_TITLE"))
-                        .toolbar {
-                            if AccountButton.shouldDisplay {
-                                AccountButton(isPresented: $presentingAccount)
-                            }
-                        }
+    }
+    
+    var body: some View {
+        NavigationStack {
+            if assessmentsIP {
+                // Displays the active assessment based on the currentTest state.
+                switch currentTest {
+                case .trailMaking:
+                    TrailMakingTaskView()
+                case .stroopTest:
+                    StroopTestView()
                 }
+            } else {
+                assessmentList
+                    .navigationTitle(String(localized: "ASSESSMENTS_NAVIGATION_TITLE"))
+                    .toolbar {
+                        if AccountButton.shouldDisplay {
+                            AccountButton(isPresented: $presentingAccount)
+                        }
+                    }
             }
         }
+    }
         
     private var trailMakingTestSection: some View {
-        Section {
+        // Button text to start the Trail Making Test or view results
+        // based on whether results are available.
+        let btnText = if tmStorageResults.isEmpty {
+            String(localized: "ASSESSMENT_TM_START_BTN")
+        } else {
+            String(localized: "ASSESSMENT_RESULTS_BTN")
+        }
+        return Section {
             VStack {
                 trailMakingTestResultsView
                 Divider()
-                .padding(.bottom, 5)
-                // Button to start the Trail Making Test or view results, based on whether results are available.
-                if tmStorageResults.isEmpty {
-                    Button(action: startTrailMaking) {
-                        Text(String(localized: "ASSESSMENT_TM_START_BTN"))
-                    }
-                    .frame(maxWidth: .infinity)
-                } else {
-                    Button(action: startTrailMaking) {
-                        Text(String(localized: "ASSESSMENT_RESULTS_BTN"))
-                    }
-                    .frame(maxWidth: .infinity)
+                    .padding(.bottom, 5)
+                Button(action: startTrailMaking) {
+                    Text(btnText)
+                        .foregroundStyle(.accent)
                 }
+                    // Use style to restrict clickable area.
+                    .buttonStyle(.plain)
             }
         }
     }
     
     private var stroopTestSection: some View {
-        Section {
+        // Button text to start the Stroop Test or view results
+        // based on whether results are available.
+        let btnText = if stroopTestResults.isEmpty {
+            String(localized: "ASSESSMENT_STROOP_START_BTN")
+        } else {
+            String(localized: "ASSESSMENT_RESULTS_BTN")
+        }
+        return Section {
             VStack {
                 stroopTestResultsView
                 Divider()
                     .padding(.bottom, 5)
-                // Button to start the Stroop Test or view results, based on whether results are available.
-                if stroopTestResults.isEmpty {
-                    Button(action: startStroopTest) {
-                        Text(String(localized: "ASSESSMENT_STROOP_START_BTN"))
-                    }
-                    .frame(maxWidth: .infinity)
-                } else {
-                    Button(action: startStroopTest) {
-                        Text(String(localized: "ASSESSMENT_RESULTS_BTN"))
-                    }
-                    .frame(maxWidth: .infinity)
+                Button(action: startStroopTest) {
+                    Text(btnText)
+                        .foregroundStyle(.accent)
                 }
+                    // Use style to restrict clickable area.
+                    .buttonStyle(.plain)
             }
         }
     }

--- a/PICS/Assessment/ResultsViz.swift
+++ b/PICS/Assessment/ResultsViz.swift
@@ -1,7 +1,7 @@
 //
 // This source file is part of the PICS based on the Stanford Spezi Template Application project
 //
-// SPDX-FileCopyrightText: 2023 Stanford University
+// SPDX-FileCopyrightText: 2024 Stanford University
 //
 // SPDX-License-Identifier: MIT
 //
@@ -15,26 +15,88 @@ struct ResultsViz: View {
     var yName: String
     var title: String
     
+    // Vars for plotting.
+    var metricType: String
+    var timeSpentLable = String(localized: "ASSESSMENT_VIZ_TIME")
+    let metricColor = Color.purple
+    let timeColor = Color.teal
+    let unSelectedColor = Color.gray
+    
+    // Vars to show detailed results.
+    @State private var selectedElement: AssessmentResult?
+    
     var body: some View {
         Text(self.title)
             .font(.title3.bold())
+            .padding(5)
         
+        // Helper text to show data when clicked or for the last result.
+        let details = getResultDetails()
+        if !details.isEmpty {
+            Text(details)
+                .font(.footnote)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .listRowSeparator(.hidden)
+        }
+
+        chart
+    }
+    
+    private var chart: some View {
         Chart {
             ForEach(data) { dataPoint in
-                PointMark(
-                    x: .value(self.xName, dataPoint.testDateTime, unit: .day),
-                    y: .value(self.yName, dataPoint.timeSpent)
-                )
-                .foregroundStyle(.blue)
-            }
-            ForEach(data) { dataPoint in
-                if dataPoint.errorCnt >= 0 {
-                    PointMark(
-                        x: .value(self.xName, dataPoint.testDateTime, unit: .day),
-                        y: .value(self.yName, dataPoint.errorCnt)
-                    )
-                    .foregroundStyle(.purple)
+                // We assume that metric might be only one of error count or score.
+                let selected = if let elm = self.selectedElement {
+                    elm.testDateTime == dataPoint.testDateTime
+                } else {
+                    false
                 }
+                let yValue = if self.metricType == String(localized: "ASSESSMENT_VIZ_SCORE") {
+                    dataPoint.score
+                } else {
+                    dataPoint.errorCnt
+                }
+                if yValue >= 0 {
+                    getLineMarker(time: dataPoint.testDateTime, selected: selected, yMark: self.metricType, yMetric: yValue)
+                }
+                
+                getLineMarker(time: dataPoint.testDateTime, selected: selected, yMark: self.timeSpentLable, yTime: dataPoint.timeSpent)
+            }
+            .lineStyle(StrokeStyle(lineWidth: 2.0))
+        }
+        .chartForegroundStyleScale([
+            self.metricType: self.metricColor,
+            self.timeSpentLable: self.timeColor
+        ])
+        .padding(10)
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 3))
+        }
+        // Use overlay to detect user's selection on marks.
+        .chartOverlay { proxy in
+            GeometryReader { geo in
+                // The rectangle to detect user's clicked position and bar.
+                Rectangle()
+                    .fill(.clear)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        SpatialTapGesture()
+                            .onEnded { value in
+                                let element = findElement(location: value.location, proxy: proxy, geometry: geo)
+                                if selectedElement?.testDateTime == element?.testDateTime {
+                                    // If tapping the same element, clear the selection.
+                                    selectedElement = nil
+                                } else {
+                                    selectedElement = element
+                                }
+                            }
+                            .exclusively(
+                                before: DragGesture()
+                                    .onChanged { value in
+                                        selectedElement = findElement(location: value.location, proxy: proxy, geometry: geo)
+                                    }
+                            )
+                    )
             }
         }
     }
@@ -44,6 +106,114 @@ struct ResultsViz: View {
         self.xName = xName
         self.yName = yName
         self.title = title
+        // We assume that we only need to plot one of error count or score.
+        let metricMax = data.map(\.errorCnt).max() ?? -1
+        self.metricType = metricMax == -1 ? String(localized: "ASSESSMENT_VIZ_SCORE") : String(localized: "ASSESSMENT_VIZ_ERRORCNT")
+    }
+
+    private func findElement(location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) -> AssessmentResult? {
+        guard let proxyF = proxy.plotFrame else {
+            print("Failed to get proxy plotframe")
+            return nil
+        }
+        let relativeXPosition = location.x - geometry[proxyF].origin.x
+        if let date = proxy.value(atX: relativeXPosition) as Date? {
+            // Find the closest date element.
+            var minDistance: TimeInterval = .infinity
+            var index: Int?
+            for dataIndex in data.indices {
+                let nthDataDistance = data[dataIndex].testDateTime.distance(to: date)
+                if abs(nthDataDistance) < minDistance {
+                    minDistance = abs(nthDataDistance)
+                     index = dataIndex
+                }
+            }
+            if let index {
+                return data[index]
+            }
+        }
+        return nil
+    }
+    
+    // Get the helper text for result to show. It should be
+    // the selected or the last result if available.
+    private func getResultDetails() -> String {
+        var prefix = ""
+        var elm: AssessmentResult
+        if let elmSel = self.selectedElement {
+            elm = elmSel
+            prefix = String(localized: "ASSESSMENT_SUMMARY")
+        } else if let elmLast = data.last {
+            elm = elmLast
+            prefix = String(localized: "ASSESSMENT_SUMMARY_LAST")
+        } else {
+            // No availabe element to show.
+            return ""
+        }
+
+        // Round the time to 2 decimal points.
+        let timeSpent = round(elm.timeSpent * 10) / 10
+        let metricNum = if self.metricType == String(localized: "ASSESSMENT_VIZ_SCORE") {
+            elm.score
+        } else {
+            elm.errorCnt
+        }
+        return (
+            prefix +
+            String(elm.testDateTime.formatted(.dateTime.year().month().day())) +
+            ":\n" +
+            self.timeSpentLable +
+            ": " +
+            String(timeSpent) +
+            ", " +
+            self.metricType +
+            ": " +
+            String(metricNum)
+        )
+    }
+    
+    // Build the line marker for time spent and metric.
+    private func getLineMarker(time: Date, selected: Bool, yMark: String, yMetric: Int = -1, yTime: Double = 0) -> some ChartContent {
+        let markColor = if yMark == self.metricType {
+            (self.selectedElement == nil) ? self.metricColor : self.unSelectedColor
+        } else {
+            (self.selectedElement == nil) ? self.timeColor : self.unSelectedColor
+        }
+
+        let mark = if yMark == self.metricType {
+            LineMark(
+                x: .value(self.xName, time, unit: .second),
+                y: .value(self.metricType, yMetric),
+                series: .value("Value", self.metricType)
+            )
+            .foregroundStyle(markColor)
+        } else {
+            LineMark(
+                x: .value(self.xName, time, unit: .second),
+                y: .value(self.timeSpentLable, yTime),
+                series: .value("Value", self.timeSpentLable)
+            )
+            .foregroundStyle(markColor)
+        }
+        let highlightColor = if yMark == self.metricType {
+            self.metricColor
+        } else {
+            self.timeColor
+        }
+       
+        // Highlight the seletion.
+        return mark.symbol {
+            if selected {
+                Circle()
+                    .strokeBorder(highlightColor, lineWidth: 2)
+                    .background(Circle().foregroundColor(highlightColor))
+                    .frame(width: 10)
+            } else {
+                Circle()
+                    .strokeBorder(markColor, lineWidth: 2)
+                    .frame(width: 5)
+            }
+        }
     }
 }
 

--- a/PICS/HealthVisulization/HKVisualizationItem.swift
+++ b/PICS/HealthVisulization/HKVisualizationItem.swift
@@ -233,7 +233,6 @@ struct HKVisualizationItem: View {
                 }
             }
             if let index {
-                print(data[index])
                 return data[index]
             }
         }

--- a/PICS/PICSDelegate.swift
+++ b/PICS/PICSDelegate.swift
@@ -19,6 +19,14 @@ import SwiftUI
 
 
 class PICSDelegate: SpeziAppDelegate {
+    // The newer Swift versions does not have a default property of window,
+    // which will cause the NSInvalidArgumentException error for Stroop
+    // assessment test. Such errors should be fixed in newer version of
+    // ResearchKit but it might not be updated in the StanfordBDHG forked
+    // version that we use. Therefore, we manually add window here to walk
+    // around the error currently.
+    var window: UIWindow?
+    
     override var configuration: Configuration {
         Configuration(standard: PICSStandard()) {
             if !FeatureFlags.disableFirebase {

--- a/PICS/Resources/Localizable.xcstrings
+++ b/PICS/Resources/Localizable.xcstrings
@@ -198,6 +198,28 @@
         }
       }
     },
+    "ASSESSMENT_SUMMARY" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your assessment result at "
+          }
+        }
+      }
+    },
+    "ASSESSMENT_SUMMARY_LAST" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your last assessment result at "
+          }
+        }
+      }
+    },
     "ASSESSMENT_TM_START_BTN" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -205,6 +227,39 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Start Assessment"
+          }
+        }
+      }
+    },
+    "ASSESSMENT_VIZ_ERRORCNT" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error Count"
+          }
+        }
+      }
+    },
+    "ASSESSMENT_VIZ_SCORE" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Score"
+          }
+        }
+      }
+    },
+    "ASSESSMENT_VIZ_TIME" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Second Spent"
           }
         }
       }
@@ -660,17 +715,6 @@
         }
       }
     },
-    "LELAND_STANFORD_BIO" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Amasa Leland Stanford (March 9, 1824 – June 21, 1893) was an American industrialist and politician. [...] He and his wife Jane were also the founders of Stanford University, which they named after their late son.\n[https://en.wikipedia.org/wiki/Leland_Stanford]"
-          }
-        }
-      }
-    },
     "LICENSE_INFO_TITLE" : {
       "localizations" : {
         "en" : {
@@ -1044,6 +1088,9 @@
           }
         }
       }
+    },
+    "Value" : {
+
     },
     "Weight" : {
 

--- a/PICS/Resources/Localizable.xcstrings
+++ b/PICS/Resources/Localizable.xcstrings
@@ -259,7 +259,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Second Spent"
+            "value" : "Time Spent (seconds)"
           }
         }
       }
@@ -768,6 +768,18 @@
           }
         }
       }
+    },
+    "NOTIFICATION_PERMISSIONS_BUTTON" : {
+
+    },
+    "NOTIFICATION_PERMISSIONS_DESCRIPTION" : {
+
+    },
+    "NOTIFICATION_PERMISSIONS_SUBTITLE" : {
+
+    },
+    "NOTIFICATION_PERMISSIONS_TITLE" : {
+
     },
     "ONBOARDING_QUESTIONNAIRE" : {
       "extractionState" : "manual",


### PR DESCRIPTION
# *Refine Assessment Charts and Fix Bugs*

## :recycle: Current situation & Problem
Previously, we set up the assessment tab with trail-making and stroop tests for #44. This PR refines the assessment tab by (1) fixing the error that stroop test fails to start, and (2) refine the chart visualizations.

## :gear: Release Notes 
- Fix the error that the app will crash when attempting to start the stroop test with `NSInvalidArgumentException`. The error was possibly due to that the delegate no longer has a window property by default in the newer version. Currently, we walk around this error by manually adding the window property back, but might be better to check with the Spezi team about whether this could be fixed by either updating the forked ResearchKit version in [StanfordBDHG](https://github.com/StanfordBDHG) or fixing it there.
- Plot the line chart of the assessment results.
- Enable highlighting the selected result line mark, and click again to de-select. Similar to the HealthKit visualizations, the charts are coded with reference to the [Swift-Charts-Examples repo](https://github.com/jordibruin/Swift-Charts-Examples/blob/main/Swift%20Charts%20Examples/Charts/LineCharts/SingleLineLollipop.swift)
- Show the result details (time spent and error count/score) when selected. If no mark is selected, show the details of the last result if available.
- Style the buttons that start assessments to restrict clickable areas to not start tests on clicking the chars. 

<p align="left">
<img src="https://github.com/CS342/2024-PICS/assets/32094663/803a9b59-434c-4fef-aab5-6b7063f004c9" width="300">
<img src="https://github.com/CS342/2024-PICS/assets/32094663/fba34759-d365-4ef6-9cdc-d12d7e5b57ba" width="300">
<img src="https://github.com/CS342/2024-PICS/assets/32094663/299cb976-3e70-4143-bb76-dffa87c1874d" width="300">
</p>

## :books: Documentation
Related comments are added to the codes.

## :white_check_mark: Testing
Manually tested in simulator.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
